### PR TITLE
Remove older documentation

### DIFF
--- a/docs/introstd.md
+++ b/docs/introstd.md
@@ -23,5 +23,4 @@ Arianee Message i18n describes the identity of a message (coming soon)
 
 ## _Deprecated schema_
 
-If you want to support the older schema for certificates, please refer to [Arianee Asset](ArianeeAsset)
-
+If you want to support our older schema for certificates, please contact us at hello@arianee.org and we will send that documentation to you. None of the older certification are in production use.


### PR DESCRIPTION
Linking to the older documentation could create confusion. It seems like nobody would want this so I have removed the link.

Justification is also given that no production certificates are using the old schema. Please confirm that is true before merging.

Documentation should be written with the goal of helping and guiding the reader. This change is proposed because referring to unused schemas will not benefit the reader and could confuse them.